### PR TITLE
PrefectureItemコンポーネントの追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.vscode/
 
 npm-debug.log*
 yarn-debug.log*

--- a/public/index.html
+++ b/public/index.html
@@ -9,35 +9,11 @@
       name="description"
       content="Web site created using create-react-app"
     />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
-    <title>React App</title>
+    <title>YumemiAssignment</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
   </body>
 </html>

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,17 @@
-import './App.css';
+import {useState} from "react"
+import "./App.css";
+import {PrefectureItem} from "./index"
 
 const App = () => {
+  const [prefecture, setPrefecture] = useState(true);
+  const PrefectureChecked = (event:any) => {
+    setPrefecture(event.target.checked);
+  }
   return (
     <>
       <h1>YumemiAssignment</h1>
+      <PrefectureItem prefecture="東京都" onChange={PrefectureChecked} />
+      <p>{prefecture?"True":"False"}</p>
     </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,6 @@ const App = () => {
     <>
       <h1>YumemiAssignment</h1>
       <PrefectureItem prefecture="東京都" onChange={PrefectureChecked} />
-      <p>{prefecture?"True":"False"}</p>
     </>
   );
 }

--- a/src/components/PrefectureItem.test.tsx
+++ b/src/components/PrefectureItem.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import PrefectureItem from './PrefectureItem';
+
+test('PrefecutureItemが与えられた都道府県を表示する', () => {
+    const prefectureName = "東京都";
+    const mockFunction = jest.fn();
+    //対象コンポーネント
+    render(<PrefectureItem prefecture={prefectureName} onChange={mockFunction}/>);
+    //テスト
+    const prefectureNameOutput = screen.getByText(new RegExp(prefectureName))
+    expect(prefectureNameOutput).toBeInTheDocument();
+});

--- a/src/components/PrefectureItem.tsx
+++ b/src/components/PrefectureItem.tsx
@@ -2,16 +2,15 @@ import {useState} from "react"
 
 interface ItemProps{
     prefecture: string;
-    isChecked: boolean;
+    onChange: any;
 }
 
 const PrefectureItem = (props :ItemProps) =>{
-    const [isChecked, setIsChecked] = useState(true);
     return (
         <label>
             <input
                 type="checkbox"
-                checked={props.isChecked}
+                onChange={props.onChange}
             />
             {props.prefecture}
         </label>

--- a/src/components/PrefectureItem.tsx
+++ b/src/components/PrefectureItem.tsx
@@ -1,0 +1,21 @@
+import {useState} from "react"
+
+interface ItemProps{
+    prefecture: string;
+    isChecked: boolean;
+}
+
+const PrefectureItem = (props :ItemProps) =>{
+    const [isChecked, setIsChecked] = useState(true);
+    return (
+        <label>
+            <input
+                type="checkbox"
+                checked={props.isChecked}
+            />
+            {props.prefecture}
+        </label>
+    );
+}
+
+export default PrefectureItem;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,5 +13,7 @@ root.render(
   </React.StrictMode>
 );
 
+export {default as PrefectureItem} from "./components/PrefectureItem"
+
 reportWebVitals();
 


### PR DESCRIPTION
## 変更の概要

* 都道府県のチェックボックスリストのアイテムコンポーネントの作成
* 都道府県名が呼び出し元から変更可能かのテストコードの作成

## やったこと

* [x] 都道府県名の表示
* [x] チェックボックスの表示
* [x] 任意の都道府県名の表示のテストコードの作成と実行
* [x] チェックボックスの有効化テスト

## 変更内容

![image](https://github.com/Bakeneko-git/population_chart_viewer/assets/67040613/b1fe6527-234c-4444-9cd0-2aa1fc3ce958)


## 影響範囲

* App.tsxに変更有り（確認用のためmainでは機能削除）

## どうやるのか

App.tsxでの記述例
`<PrefectureItem prefecture="東京都" onChange={PrefectureChecked} />`