### PR TITLE
PrefecturesListコンポーネントの追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,18 @@
-import {useState} from "react"
+import { useState } from "react";
 import "./App.css";
-import {PrefectureItem} from "./index"
+import { PrefectureItem } from "./index";
 
 const App = () => {
-  const [prefecture, setPrefecture] = useState(true);
-  const PrefectureChecked = (event:any) => {
-    setPrefecture(event.target.checked);
-  }
-  return (
-    <>
-      <h1>YumemiAssignment</h1>
-      <PrefectureItem prefecture="東京都" onChange={PrefectureChecked} />
-    </>
-  );
-}
+    const [prefecture, setPrefecture] = useState(true);
+    const PrefectureChecked = (event: any) => {
+        setPrefecture(event.target.checked);
+    };
+    return (
+        <>
+            <h1>YumemiAssignment</h1>
+            <PrefectureItem prefecture="東京都" onChange={PrefectureChecked} />
+        </>
+    );
+};
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,16 @@
 import { useState } from "react";
 import "./App.css";
-import { PrefectureItem } from "./index";
+import { PrefecturesList } from "./index";
 
 const App = () => {
-    const [prefecture, setPrefecture] = useState(true);
-    const PrefectureChecked = (event: any) => {
-        setPrefecture(event.target.checked);
+    const [prefectures, setPrefectures] = useState({"東京都":false,"大阪府":false,"北海道":false});
+    const PrefecturesChecked = (event: any, index: string) => {
+        setPrefectures({...prefectures, [index]:event.target.checked});
     };
     return (
         <>
             <h1>YumemiAssignment</h1>
-            <PrefectureItem prefecture="東京都" onChange={PrefectureChecked} />
+            <PrefecturesList prefectures={prefectures} onChange={PrefecturesChecked} />
         </>
     );
 };

--- a/src/components/PrefectureItem.test.tsx
+++ b/src/components/PrefectureItem.test.tsx
@@ -1,12 +1,14 @@
-import { render, screen } from '@testing-library/react';
-import PrefectureItem from './PrefectureItem';
+import { render, screen } from "@testing-library/react";
+import PrefectureItem from "./PrefectureItem";
 
-test('PrefecutureItemが与えられた都道府県を表示する', () => {
+test("PrefecutureItemが与えられた都道府県を表示する", () => {
     const prefectureName = "東京都";
     const mockFunction = jest.fn();
     //対象コンポーネント
-    render(<PrefectureItem prefecture={prefectureName} onChange={mockFunction}/>);
+    render(
+        <PrefectureItem prefecture={prefectureName} onChange={mockFunction} />
+    );
     //テスト
-    const prefectureNameOutput = screen.getByText(new RegExp(prefectureName))
+    const prefectureNameOutput = screen.getByText(new RegExp(prefectureName));
     expect(prefectureNameOutput).toBeInTheDocument();
 });

--- a/src/components/PrefectureItem.tsx
+++ b/src/components/PrefectureItem.tsx
@@ -1,20 +1,17 @@
-import {useState} from "react"
+import { useState } from "react";
 
-interface ItemProps{
+interface ItemProps {
     prefecture: string;
     onChange: any;
 }
 
-const PrefectureItem = (props :ItemProps) =>{
+const PrefectureItem = (props: ItemProps) => {
     return (
         <label>
-            <input
-                type="checkbox"
-                onChange={props.onChange}
-            />
+            <input type="checkbox" onChange={props.onChange} />
             {props.prefecture}
         </label>
     );
-}
+};
 
 export default PrefectureItem;

--- a/src/components/PrefecturesList.test.tsx
+++ b/src/components/PrefecturesList.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import PrefecturesList from "./PrefecturesList";
+
+test("PrefecuturesListが与えられた都道府県配列を表示する", () => {
+    const prefectures = {"東京都":false,"大阪府":true,"北海道":false};
+    const mockOnChange = jest.fn();
+    //対象コンポーネント
+    render(
+        <PrefecturesList prefectures={prefectures} onChange={mockOnChange}/>
+    );
+    //表示項目が期待通り揃うか？
+    const prefectureName1 = screen.getByText(new RegExp("東京都"));
+    expect(prefectureName1).toBeInTheDocument();
+    const prefectureName2 = screen.getByText(new RegExp("大阪府"));
+    expect(prefectureName2).toBeInTheDocument();
+    const prefectureName3 = screen.getByText(new RegExp("北海道"));
+    expect(prefectureName3).toBeInTheDocument();
+});

--- a/src/components/PrefecturesList.tsx
+++ b/src/components/PrefecturesList.tsx
@@ -1,0 +1,13 @@
+import PrefectureItem from "./PrefectureItem";
+
+const PrefecturesList = (props: any) => {
+    const prefectures = props.prefectures;
+    return (
+        <>
+            {Object.entries(prefectures).map(([name, check]) => (
+                <PrefectureItem key={name} prefecture={name} onChange={(event: any) => props.onChange(event,name)} />
+            ))}
+        </>
+    );
+};
+export default PrefecturesList;

--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,13 @@
 body {
-  margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto",
+        "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans",
+        "Helvetica Neue", sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+    font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
+        monospace;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,19 +1,18 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import './index.css';
-import App from './App';
-import reportWebVitals from './reportWebVitals';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import "./index.css";
+import App from "./App";
+import reportWebVitals from "./reportWebVitals";
 
 const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement
+    document.getElementById("root") as HTMLElement
 );
 root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
+    <React.StrictMode>
+        <App />
+    </React.StrictMode>
 );
 
-export {default as PrefectureItem} from "./components/PrefectureItem"
+export { default as PrefectureItem } from "./components/PrefectureItem";
 
 reportWebVitals();
-

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,6 @@ root.render(
     </React.StrictMode>
 );
 
-export { default as PrefectureItem } from "./components/PrefectureItem";
+export { default as PrefecturesList } from "./components/PrefecturesList";
 
 reportWebVitals();

--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -1,15 +1,17 @@
-import { ReportHandler } from 'web-vitals';
+import { ReportHandler } from "web-vitals";
 
 const reportWebVitals = (onPerfEntry?: ReportHandler) => {
-  if (onPerfEntry && onPerfEntry instanceof Function) {
-    import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
-      getCLS(onPerfEntry);
-      getFID(onPerfEntry);
-      getFCP(onPerfEntry);
-      getLCP(onPerfEntry);
-      getTTFB(onPerfEntry);
-    });
-  }
+    if (onPerfEntry && onPerfEntry instanceof Function) {
+        import("web-vitals").then(
+            ({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
+                getCLS(onPerfEntry);
+                getFID(onPerfEntry);
+                getFCP(onPerfEntry);
+                getLCP(onPerfEntry);
+                getTTFB(onPerfEntry);
+            }
+        );
+    }
 };
 
 export default reportWebVitals;


### PR DESCRIPTION
# 変更の概要
- {都道府県名:bool,...}形式の辞書型データに沿って都道府県チェックボックス一覧を表示する関数の作成
- 正しく一覧表示ができているかのテストコードの作成

# やったこと
- [x] PrefectureItemコンポーネントを与えられた辞書型データの数だけ表示する関数の作成
- [x] 与えられたデータ分都道府県をチェックボックス一覧表示できているか確認
- [x] 正しく表示されているかどうかを確認を行うテストコードの作成と実行 
- [x] エンドポイントの追加

# 変更内容
- PrefecturesListコンポーネントの追加

# 影響範囲
- App.tsxに変更有り。（確認用のためmainでは機能削除してよし）

# どうやるのか
- App.tsxに例あり