### PR TITLE
メインページの都道府県選択部分の作成

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,11 +7,7 @@ const App = () => {
         message: "",
         result: [],
     });
-    const [prefectures, setPrefectures] = useState({
-        東京都: false,
-        大阪府: false,
-        北海道: false,
-    });
+    const [prefectures, setPrefectures] = useState({});
     const PrefecturesUpdate = async (data: any) => {
         await setPrefecturesJson(data);
     };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,33 +1,42 @@
-
 import { useEffect, useState } from "react";
 import "./App.css";
 import { PrefecturesList, GetPrefecturesJson } from "./index";
 
 const App = () => {
-    const [prefecturesJson, setPrefecturesJson] = useState({message:"",result:[]});
-    const [prefectures, setPrefectures] = useState({"東京都":false,"大阪府":false,"北海道":false});
-    const PrefecturesUpdate = async(data: any) => {
+    const [prefecturesJson, setPrefecturesJson] = useState({
+        message: "",
+        result: [],
+    });
+    const [prefectures, setPrefectures] = useState({
+        東京都: false,
+        大阪府: false,
+        北海道: false,
+    });
+    const PrefecturesUpdate = async (data: any) => {
         await setPrefecturesJson(data);
     };
     const PrefecturesChecked = (event: any, index: string) => {
-        setPrefectures({...prefectures, [index]:event.target.checked});
+        setPrefectures({ ...prefectures, [index]: event.target.checked });
     };
     useEffect(() => {
         (async () => {
             //初回実行で都道府県名を取得
             const result = await GetPrefecturesJson();
-            const transformdData:any = {};
+            const transformdData: any = {};
             PrefecturesUpdate(result);
-            result.result.forEach((item:any) => {
+            result.result.forEach((item: any) => {
                 transformdData[item.prefName] = false;
-            })
+            });
             setPrefectures(transformdData);
         })();
     }, []);
     return (
         <>
             <h1>YumemiAssignment</h1>
-            <PrefecturesList prefectures={prefectures} onChange={PrefecturesChecked} />
+            <PrefecturesList
+                prefectures={prefectures}
+                onChange={PrefecturesChecked}
+            />
         </>
     );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,17 +4,25 @@ import "./App.css";
 import { PrefecturesList, GetPrefecturesJson } from "./index";
 
 const App = () => {
-    const [prefecturesJson, setPrefecturesJson] = useState("");
+    const [prefecturesJson, setPrefecturesJson] = useState({message:"",result:[]});
     const [prefectures, setPrefectures] = useState({"東京都":false,"大阪府":false,"北海道":false});
-    const prefecturesUpdate = (data: string) => {
-        setPrefecturesJson(data);
+    const PrefecturesUpdate = async(data: any) => {
+        await setPrefecturesJson(data);
     };
     const PrefecturesChecked = (event: any, index: string) => {
         setPrefectures({...prefectures, [index]:event.target.checked});
     };
     useEffect(() => {
-        //初回実行で都道府県名を取得
-        GetPrefecturesJson(prefecturesUpdate);
+        (async () => {
+            //初回実行で都道府県名を取得
+            const result = await GetPrefecturesJson();
+            const transformdData:any = {};
+            PrefecturesUpdate(result);
+            result.result.forEach((item:any) => {
+                transformdData[item.prefName] = false;
+            })
+            setPrefectures(transformdData);
+        })();
     }, []);
     return (
         <>

--- a/src/components/GetPrefecturesJson.test.tsx
+++ b/src/components/GetPrefecturesJson.test.tsx
@@ -20,10 +20,8 @@ test("都道府県一覧を取得できているか", async () => {
         json: () => Promise.resolve(mockJson),
     });
 
-    GetPrefecturesJson((data: any) => {
-        //正しく取得されるか
-        expect(data).toEqual(mockJson);
-    });
+    //正しく取得されるか
+    expect(GetPrefecturesJson()).toEqual(mockJson);
 
     // APIが正しく呼び出されたかを確認
     expect(fetch).toHaveBeenCalledWith(

--- a/src/components/GetPrefecturesJson.tsx
+++ b/src/components/GetPrefecturesJson.tsx
@@ -1,4 +1,4 @@
-const GetPrefecturesJson = async() => {
+const GetPrefecturesJson = async () => {
     const apikey = process.env.REACT_APP_RESAS_API_KEY;
     const headers: Record<string, string> = {
         "X-API-KEY": apikey !== undefined ? apikey : "",
@@ -10,8 +10,7 @@ const GetPrefecturesJson = async() => {
     const result = await fetch(
         "https://opendata.resas-portal.go.jp/api/v1/prefectures",
         requestOptions
-    )
-        .then((response) => response.json())
+    ).then((response) => response.json());
     return result;
 };
 

--- a/src/components/GetPrefecturesJson.tsx
+++ b/src/components/GetPrefecturesJson.tsx
@@ -1,4 +1,4 @@
-const GetPrefecturesJson = (callback: CallableFunction) => {
+const GetPrefecturesJson = async() => {
     const apikey = process.env.REACT_APP_RESAS_API_KEY;
     const headers: Record<string, string> = {
         "X-API-KEY": apikey !== undefined ? apikey : "",
@@ -7,12 +7,12 @@ const GetPrefecturesJson = (callback: CallableFunction) => {
     const requestOptions: RequestInit = {
         headers: headers,
     };
-    fetch(
+    const result = await fetch(
         "https://opendata.resas-portal.go.jp/api/v1/prefectures",
         requestOptions
     )
         .then((response) => response.json())
-        .then((data) => callback(data));
+    return result;
 };
 
 export default GetPrefecturesJson;


### PR DESCRIPTION
# 変更の概要
- GetPrefectuesJsonで取得した内容を、PrefecturesListで表示する。
- チェックボックスにチェックを入れると、prefecturesの変更状態のStateが変更される。

# やったこと
- [x] GetPrefecturesJsonで取得した内容を、PrefecturesListで表示できるようにする。

# 変更内容
- ページに都道府県選択部分を作成
![image](https://github.com/Bakeneko-git/population_chart_viewer/assets/67040613/0deed9b2-05c3-4e4f-a0ea-4ae058c4474b)

# 影響範囲
- GetPrefecturesJsonの仕様を一部変更
- App.tsxを主に変更。
